### PR TITLE
Add vitest config and hook tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@canvasjs/react-charts": "^1.0.2",
@@ -41,6 +42,9 @@
     "globals": "^15.15.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.3",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.5"
   }
 }

--- a/src/hooks/useDolares.test.js
+++ b/src/hooks/useDolares.test.js
@@ -1,0 +1,26 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import * as dolarService from '../services/dolarService';
+import useDolares from './useDolares';
+
+vi.mock('../services/dolarService');
+
+describe('useDolares', () => {
+  it('sets dolares on successful fetch', async () => {
+    dolarService.fetchDolares.mockResolvedValue([{ nombre: 'Oficial', venta: 1 }]);
+
+    const { result } = renderHook(() => useDolares());
+
+    await waitFor(() => expect(result.current.dolares).toHaveLength(1));
+    expect(result.current.dolares[0].nombre).toBe('Oficial');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on fetch failure', async () => {
+    dolarService.fetchDolares.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useDolares());
+
+    await waitFor(() => expect(result.current.error).toBe('fail'));
+    expect(result.current.dolares).toEqual([]);
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   // base: '/DolarActual/',
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.js'
+  }
 })

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- configure Vitest and add setup file
- add a test for `useDolares` hook
- expose test script in `package.json`

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b96e64dd08332b04d6677f1354584